### PR TITLE
Minor math issues

### DIFF
--- a/transforms/ctl/utilities/ACESlib.Utilities.a1.0.0.ctl
+++ b/transforms/ctl/utilities/ACESlib.Utilities.a1.0.0.ctl
@@ -105,13 +105,13 @@ float[3] log10_f3( float a[3])
 
 float round(float x)
 {
-  float x1;
-
+  int x1;
+ 
   if (x < 0.0)
-    x1 = floor( x - 0.5);
+    x1 = x - 0.5;
   else
-    x1 = floor( x + 0.5);
-
+    x1 = x + 0.5;
+ 
   return x1;
 }
 

--- a/transforms/ctl/utilities/ACESlib.Utilities_Color.a1.0.0.ctl
+++ b/transforms/ctl/utilities/ACESlib.Utilities_Color.a1.0.0.ctl
@@ -196,7 +196,7 @@ float[3][3] calculate_cat_matrix
       { 0.0, 0.0, des_coneResp[2] / src_coneResp[2] }
   };
 
-  float cat_matrix[3][3] = mult_f33_f33( coneRespMat, transpose_f33( mult_f33_f33( transpose_f33( invert_f33( coneRespMat ) ), vkMat ) ) );
+  float cat_matrix[3][3] = mult_f33_f33( coneRespMat, mult_f33_f33( vkMat, invert_f33( coneRespMat ) ) );
 
   return cat_matrix;
 }


### PR DESCRIPTION
Here are a couple of commits that address minor math issues:
* round() doesn't handle negative values correctly in all cases. Fortunately the function doesn't appear to be used anywhere! (Alternative solutions: write x1 = -floor(-x + 0.5) for the negative branch, or remove the function altogether)
* calculate_cat_matrix() performs unnecessary matrix transposes