### PR TITLE
correcting the BT.709 white point

### DIFF
--- a/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.a1.0.0.ctl
+++ b/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.a1.0.0.ctl
@@ -20,7 +20,7 @@
 //              Red:          0.64      0.33
 //              Green:        0.3       0.6
 //              Blue:         0.15      0.06
-//              White:        0.3217    0.329     100 cd/m^2
+//              White:        0.3127    0.329     100 cd/m^2
 //
 // Display EOTF :
 //  The reference electro-optical transfer function specified in 

--- a/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0.ctl
+++ b/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.0.ctl
@@ -20,7 +20,7 @@
 //              Red:          0.64      0.33
 //              Green:        0.3       0.6
 //              Blue:         0.15      0.06
-//              White:        0.3217    0.329     100 cd/m^2
+//              White:        0.3127    0.329     100 cd/m^2
 //
 // Display EOTF :
 //  The reference electro-optical transfer function specified in 


### PR DESCRIPTION
The errors are just in the comments.  The actual matrix in transforms/ctl/utilities/ACESlib.Utilities_Color.a1.0.0.ctl is correct.

I don't know why it's showing the last line of each file as a difference.  I didn't change it.