### PR TITLE
Simplified log math in lin_to_log2_32f

### DIFF
--- a/transforms/ctl/utilities/ACESlib.Lin_to_Log2_param.a1.0.1.ctl
+++ b/transforms/ctl/utilities/ACESlib.Lin_to_Log2_param.a1.0.1.ctl
@@ -17,7 +17,7 @@ float lin_to_log2_32f
 {
   if (lin <= 0.0) return 0.0;
 
-  float log2 = (log10(lin / middleGrey) / log10(2.0));
+  float log2 = log2(lin / middleGrey);
   float logNorm = (log2 - minExposure)/(maxExposure - minExposure);
 
   if( logNorm < 0.0) logNorm = 0;

--- a/transforms/ctl/utilities/ACESlib.Lin_to_Log2_param.a1.0.1.ctl
+++ b/transforms/ctl/utilities/ACESlib.Lin_to_Log2_param.a1.0.1.ctl
@@ -17,8 +17,8 @@ float lin_to_log2_32f
 {
   if (lin <= 0.0) return 0.0;
 
-  float log2 = log2(lin / middleGrey);
-  float logNorm = (log2 - minExposure)/(maxExposure - minExposure);
+  float lg2 = log2(lin / middleGrey);
+  float logNorm = (lg2 - minExposure)/(maxExposure - minExposure);
 
   if( logNorm < 0.0) logNorm = 0;
 

--- a/transforms/ctl/utilities/ACESlib.Log2_to_Lin_param.a1.0.1.ctl
+++ b/transforms/ctl/utilities/ACESlib.Log2_to_Lin_param.a1.0.1.ctl
@@ -17,8 +17,8 @@ float log2_to_lin_32f
 {
   if (logNorm < 0.0) return 0.0;
 
-  float log2 = logNorm*(maxExposure - minExposure) + minExposure;
-  float lin = pow(2.0, log2) * middleGrey;
+  float lg2 = logNorm*(maxExposure - minExposure) + minExposure;
+  float lin = pow(2.0, lg2) * middleGrey;
   
   return lin;
 }


### PR DESCRIPTION
I also have a commit that simplifies some tonescale logic by precomputing log min/mid/maxPoint values, which I could add to the PR:
https://github.com/selfshadow/aces-dev/commit/07c78ad132baee5942f2e73fbc6f0c91325acdda

This feels more consistent to me since the knot values are in "log space", but perhaps the existing code was written this way to simplify the struct definitions.
