### PR TITLE
update to function parameters in ODTs

### DIFF
--- a/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl
+++ b/transforms/ctl/odt/rec2020/InvODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl
@@ -36,13 +36,13 @@ void main
     output varying float gOut,
     output varying float bOut,
     output varying float aOut,
-    input varying int legalRange = 0
+    input uniform bool legalRange = false
 )
 {  
     float outputCV[3] = { rIn, gIn, bIn};
 
   // Default output is full range, check if legalRange param was set to true
-    if (legalRange == 1) {
+    if (legalRange) {
       outputCV = smpteRange_to_fullRange_f3( outputCV);
     }
 

--- a/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl
+++ b/transforms/ctl/odt/rec2020/ODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl
@@ -71,7 +71,7 @@ void main
     output varying float gOut,
     output varying float bOut,
     output varying float aOut,
-    input varying int legalRange = 0
+    input uniform bool legalRange = false
 )
 {
     float oces[3] = { rIn, gIn, bIn};
@@ -118,7 +118,7 @@ void main
     outputCV[2] = bt1886_r( linearCV[2], DISPGAMMA, L_W, L_B);
 
   // Default output is full range, check if legalRange param was set to true
-    if (legalRange == 1) {
+    if (legalRange) {
       outputCV = fullRange_to_smpteRange_f3( outputCV);
     }
 

--- a/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.a1.0.1.ctl
+++ b/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_100nits_dim.a1.0.1.ctl
@@ -35,13 +35,13 @@ void main
     output varying float gOut,
     output varying float bOut,
     output varying float aOut,
-    input varying int legalRange = 0
+    input uniform bool legalRange = false
 )
 {  
     float outputCV[3] = { rIn, gIn, bIn};
 
   // Default output is full range, check if legalRange param was set to true
-    if (legalRange == 1) {
+    if (legalRange) {
       outputCV = smpteRange_to_fullRange_f3( outputCV);
     }
 

--- a/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl
+++ b/transforms/ctl/odt/rec709/InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl
@@ -37,13 +37,13 @@ void main
     output varying float gOut,
     output varying float bOut,
     output varying float aOut,
-    input varying int legalRange = 0
+    input uniform bool legalRange = false
 )
 {  
     float outputCV[3] = { rIn, gIn, bIn};
 
   // Default output is full range, check if legalRange param was set to true
-    if (legalRange == 1) {
+    if (legalRange) {
       outputCV = smpteRange_to_fullRange_f3( outputCV);
     }
 

--- a/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.a1.0.1.ctl
+++ b/transforms/ctl/odt/rec709/ODT.Academy.Rec709_100nits_dim.a1.0.1.ctl
@@ -70,7 +70,7 @@ void main
     output varying float gOut,
     output varying float bOut,
     output varying float aOut,
-    input varying int legalRange = 0
+    input uniform bool legalRange = false
 )
 {
     float oces[3] = { rIn, gIn, bIn};
@@ -117,7 +117,7 @@ void main
     outputCV[2] = bt1886_r( linearCV[2], DISPGAMMA, L_W, L_B);
 
   // Default output is full range, check if legalRange param was set to true
-    if (legalRange == 1) {
+    if (legalRange) {
       outputCV = fullRange_to_smpteRange_f3( outputCV);
     }
 

--- a/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl
+++ b/transforms/ctl/odt/rec709/ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl
@@ -72,7 +72,7 @@ void main
     output varying float gOut,
     output varying float bOut,
     output varying float aOut,
-    input varying int legalRange = 0
+    input uniform bool legalRange = false
 )
 {
     float oces[3] = { rIn, gIn, bIn};
@@ -135,7 +135,7 @@ void main
     outputCV[2] = bt1886_r( linearCV[2], DISPGAMMA, L_W, L_B);
 
   // Default output is full range, check if legalRange param was set to true
-    if (legalRange == 1) {
+    if (legalRange) {
       outputCV = fullRange_to_smpteRange_f3( outputCV);
     }
 


### PR DESCRIPTION
The changes in this pull request update the declarations for the function parameters and parameter variable types in ODTs that supply a default parameter. 

Specifically:
* the _varyingHint_ for function parameters are changed from `varying` to `uniform`
* the variable _baseType_ is changed from `int` to `bool`

The update in this pull request has been suggested as a fix for an issue where the CTL interpreter can inconsistently provide a default value. For example, when `legalRange` is specified as a varying parameter and not supplied explicitly in calls to the interpreter, sometimes the returned values are in legal range and other times in full range. Changing the `varying` hint to `uniform` seems to resolve this issue for the test cases that first showed the inconsistency.