### PR TITLE
Add RGBmonitor D65 fwd and inv ODTs

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -65,6 +65,7 @@ ACEScc and ACESproxy image data is **NOT** intended to be written out to image f
     * *SonyF35.StillLife_from_ODT.Academy.Rec709_D60sim_100nits_dim.exr* - `InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.Rec709_D60sim_100nits_dim.tiff*
     * *SonyF35.StillLife_from_ODT.Academy.Rec2020_100nits_dim.exr* - `InvODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.Rec2020_100nits_dim.tiff*
     * *SonyF35.StillLife_from_ODT.Academy.RGBmonitor_D60sim_100nits_dim.exr* - `InvODT.Academy.DCDM.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.RGBmonitor_D60sim_100nits_dim.tiff*
+    * *SonyF35.StillLife_from_ODT.Academy.RGBmonitor_100nits_dim.exr* - `InvODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.RGBmonitor_100nits_dim.tiff*
     * *syntheticChart.01_from_ODT.Academy.DCDM_P3D60.exr* - `InvODT.Academy.DCDM.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.DCDM_P3D60.tiff*
     * *syntheticChart.01_from_ODT.Academy.DCDM.exr* - `InvODT.Academy.DCDM.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.DCDM.tiff*
     * *syntheticChart.01_from_ODT.Academy.P3D60_48nits.exr* - `InvODT.Academy.P3D60_48nits.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.P3D60_48nits.tiff*
@@ -77,6 +78,7 @@ ACEScc and ACESproxy image data is **NOT** intended to be written out to image f
     * *syntheticChart.01_from_ODT.Academy.Rec709_D60sim_100nits_dim.exr* - `InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.Rec709_D60sim_100nits_dim.tiff*
     * *syntheticChart.01_from_ODT.Academy.Rec2020_100nits_dim.exr* - `InvODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.Rec2020_100nits_dim.tiff*
     * *syntheticChart.01_from_ODT.Academy.RGBmonitor_D60sim_100nits_dim.exr* - `InvODT.Academy.DCDM.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.RGBmonitor_D60sim_100nits_dim.tiff*
+    * *syntheticChart.01_from_ODT.Academy.RGBmonitor_100nits_dim.exr* - `InvODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.RGBmonitor_100nits_dim.tiff*
   * **LMT/**
     * *SonyF35.StillLife_LMT.Academy.ACES_0_1_1.exr* - `LMT.Academy.ACES_0_1_1.a1.0.1.ctl` applied to *ACES/SonyF35.StillLife.exr*
     * *SonyF35.StillLife_LMT.Academy.ACES_0_2_2.exr* - `LMT.Academy.ACES_0_2_2.a1.0.1.ctl` applied to *ACES/SonyF35.StillLife.exr*
@@ -100,6 +102,7 @@ ACEScc and ACESproxy image data is **NOT** intended to be written out to image f
     * *SonyF35.StillLife_ODT.Academy.Rec709_D60sim_100nits_dim.tiff* - `ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl` applied to *OCES/SonyF35.StillLife.exr*    
     * *SonyF35.StillLife_ODT.Academy.Rec2020_100nits_dim.tiff* - `ODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl` applied to *OCES/SonyF35.StillLife.exr*    
     * *SonyF35.StillLife_ODT.Academy.RGBmonitor_D60sim_100nits_dim.tiff* - `ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1.ctl` applied to *OCES/SonyF35.StillLife.exr*    
+    * *SonyF35.StillLife_ODT.Academy.RGBmonitor_100nits_dim.tiff* - `ODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl` applied to *OCES/SonyF35.StillLife.exr*    
     * *syntheticChart.01_ODT.Academy.DCDM_P3D60.tiff* - `ODT.Academy.DCDM_P3D60.a1.0.1.ctl` applied to *OCES/syntheticChart.01.exr*
     * *syntheticChart.01_ODT.Academy.DCDM.tiff* - `ODT.Academy.DCDM.a1.0.1.ctl` applied to *OCES/syntheticChart.01.exr*    
     * *syntheticChart.01_ODT.Academy.P3D60_48nits.tiff* - `ODT.Academy.P3D60_48nits.a1.0.1.ctl` applied to *OCES/syntheticChart.01.exr*    
@@ -112,3 +115,4 @@ ACEScc and ACESproxy image data is **NOT** intended to be written out to image f
     * *syntheticChart.01_ODT.Academy.Rec709_D60sim_100nits_dim.tiff* - `ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl` applied to *OCES/syntheticChart.01.exr*    
     * *syntheticChart.01_ODT.Academy.Rec2020_100nits_dim.tiff* - `ODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl` applied to *OCES/syntheticChart.01.exr*    
     * *syntheticChart.01_ODT.Academy.RGBmonitor_D60sim_100nits_dim.tiff* - `ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1.ctl` applied to *OCES/syntheticChart.01.exr*    
+    * *syntheticChart.01_ODT.Academy.RGBmonitor_100nits_dim.tiff* - `ODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl` applied to *OCES/syntheticChart.01.exr*    

--- a/images/README.md
+++ b/images/README.md
@@ -64,7 +64,7 @@ ACEScc and ACESproxy image data is **NOT** intended to be written out to image f
     * *SonyF35.StillLife_from_ODT.Academy.Rec709_100nits_dim.exr* - `InvODT.Academy.Rec709_100nits_dim.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.Rec709_100nits_dim.tiff*
     * *SonyF35.StillLife_from_ODT.Academy.Rec709_D60sim_100nits_dim.exr* - `InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.Rec709_D60sim_100nits_dim.tiff*
     * *SonyF35.StillLife_from_ODT.Academy.Rec2020_100nits_dim.exr* - `InvODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.Rec2020_100nits_dim.tiff*
-    * *SonyF35.StillLife_from_ODT.Academy.RGBmonitor_D60sim_100nits_dim.exr* - `InvODT.Academy.DCDM.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.RGBmonitor_D60sim_100nits_dim.tiff*
+    * *SonyF35.StillLife_from_ODT.Academy.RGBmonitor_D60sim_100nits_dim.exr* - `InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.RGBmonitor_D60sim_100nits_dim.tiff*
     * *SonyF35.StillLife_from_ODT.Academy.RGBmonitor_100nits_dim.exr* - `InvODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl` applied to *ODT/SonyF35.StillLife_ODT.Academy.RGBmonitor_100nits_dim.tiff*
     * *syntheticChart.01_from_ODT.Academy.DCDM_P3D60.exr* - `InvODT.Academy.DCDM.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.DCDM_P3D60.tiff*
     * *syntheticChart.01_from_ODT.Academy.DCDM.exr* - `InvODT.Academy.DCDM.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.DCDM.tiff*
@@ -77,7 +77,7 @@ ACEScc and ACESproxy image data is **NOT** intended to be written out to image f
     * *syntheticChart.01_from_ODT.Academy.Rec709_100nits_dim.exr* - `InvODT.Academy.Rec709_100nits_dim.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.Rec709_100nits_dim.tiff*
     * *syntheticChart.01_from_ODT.Academy.Rec709_D60sim_100nits_dim.exr* - `InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.Rec709_D60sim_100nits_dim.tiff*
     * *syntheticChart.01_from_ODT.Academy.Rec2020_100nits_dim.exr* - `InvODT.Academy.Rec2020_100nits_dim.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.Rec2020_100nits_dim.tiff*
-    * *syntheticChart.01_from_ODT.Academy.RGBmonitor_D60sim_100nits_dim.exr* - `InvODT.Academy.DCDM.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.RGBmonitor_D60sim_100nits_dim.tiff*
+    * *syntheticChart.01_from_ODT.Academy.RGBmonitor_D60sim_100nits_dim.exr* - `InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.RGBmonitor_D60sim_100nits_dim.tiff*
     * *syntheticChart.01_from_ODT.Academy.RGBmonitor_100nits_dim.exr* - `InvODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl` applied to *ODT/syntheticChart.01_ODT.Academy.RGBmonitor_100nits_dim.tiff*
   * **LMT/**
     * *SonyF35.StillLife_LMT.Academy.ACES_0_1_1.exr* - `LMT.Academy.ACES_0_1_1.a1.0.1.ctl` applied to *ACES/SonyF35.StillLife.exr*

--- a/transforms/ctl/odt/rgbMonitor/InvODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl
+++ b/transforms/ctl/odt/rgbMonitor/InvODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl
@@ -1,0 +1,83 @@
+
+// <ACEStransformID>InvODT.Academy.RGBmonitor_100nits_dim.a1.0.1</ACEStransformID>
+// <ACESuserName>ACES 1.0 Inverse Output - sRGB</ACESuserName>
+
+// 
+// Inverse Output Device Transform - RGB computer monitor
+//
+
+
+
+import "ACESlib.Utilities.a1.0.1";
+import "ACESlib.Transform_Common.a1.0.1";
+import "ACESlib.ODT_Common.a1.0.1";
+import "ACESlib.Tonescales.a1.0.1";
+
+
+
+/* ----- ODT Parameters ------ */
+const Chromaticities DISPLAY_PRI = REC709_PRI;
+const float DISPLAY_PRI_2_XYZ_MAT[4][4] = RGBtoXYZ(DISPLAY_PRI,1.0);
+
+const float DISPGAMMA = 2.4; 
+const float OFFSET = 0.055;
+
+
+
+void main 
+(
+    input varying float rIn, 
+    input varying float gIn, 
+    input varying float bIn, 
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{  
+    float outputCV[3] = { rIn, gIn, bIn};
+
+  // Decode to linear code values with inverse transfer function
+    float linearCV[3];
+    // moncurve_f with gamma of 2.4 and offset of 0.055 matches the EOTF found in IEC 61966-2-1:1999 (sRGB)
+    linearCV[0] = moncurve_f( outputCV[0], DISPGAMMA, OFFSET);
+    linearCV[1] = moncurve_f( outputCV[1], DISPGAMMA, OFFSET);
+    linearCV[2] = moncurve_f( outputCV[2], DISPGAMMA, OFFSET);
+
+  // Convert from display primary encoding
+    // Display primaries to CIE XYZ
+    float XYZ[3] = mult_f3_f44( linearCV, DISPLAY_PRI_2_XYZ_MAT);
+    
+    // Apply CAT from assumed observer adapted white to ACES white point
+    XYZ = mult_f3_f33( XYZ, invert_f33( D60_2_D65_CAT));
+  
+    // CIE XYZ to rendering space RGB
+    linearCV = mult_f3_f44( XYZ, XYZ_2_AP1_MAT);
+
+  // Undo desaturation to compensate for luminance difference
+    linearCV = mult_f3_f33( linearCV, invert_f33( ODT_SAT_MAT));
+
+  // Undo gamma adjustment to compensate for dim surround
+    linearCV = dimSurround_to_darkSurround( linearCV);
+
+  // Scale linear code value to luminance
+    float rgbPre[3];
+    rgbPre[0] = linCV_2_Y( linearCV[0], CINEMA_WHITE, CINEMA_BLACK);
+    rgbPre[1] = linCV_2_Y( linearCV[1], CINEMA_WHITE, CINEMA_BLACK);
+    rgbPre[2] = linCV_2_Y( linearCV[2], CINEMA_WHITE, CINEMA_BLACK);
+
+  // Apply the tonescale independently in rendering-space RGB
+    float rgbPost[3];
+    rgbPost[0] = segmented_spline_c9_rev( rgbPre[0]);
+    rgbPost[1] = segmented_spline_c9_rev( rgbPre[1]);
+    rgbPost[2] = segmented_spline_c9_rev( rgbPre[2]);
+
+  // Rendering space RGB to OCES
+    float oces[3] = mult_f3_f44( rgbPost, AP1_2_AP0_MAT);
+
+    rOut = oces[0];
+    gOut = oces[1];
+    bOut = oces[2];
+    aOut = aIn;
+}

--- a/transforms/ctl/odt/rgbMonitor/ODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl
+++ b/transforms/ctl/odt/rgbMonitor/ODT.Academy.RGBmonitor_100nits_dim.a1.0.1.ctl
@@ -1,0 +1,126 @@
+
+// <ACEStransformID>ODT.Academy.RGBmonitor_100nits_dim.a1.0.1</ACEStransformID>
+// <ACESuserName>ACES 1.0 Output - sRGB</ACESuserName>
+
+// 
+// Output Device Transform - RGB computer monitor
+//
+
+//
+// Summary :
+//  This transform is intended for mapping OCES onto a desktop computer monitor 
+//  typical of those used in motion picture visual effects production used to 
+//  simulate the image appearance produced by odt_p3d60. These monitors may
+//  occasionally be referred to as "sRGB" displays, however, the monitor for
+//  which this transform is designed does not exactly match the specifications
+//  in IEC 61966-2-1:1999.
+// 
+//  The assumed observer adapted white is D65, and the viewing environment is 
+//  that of a dim surround. 
+//
+//  The monitor specified is intended to be more typical of those found in 
+//  visual effects production.
+//
+// Device Primaries : 
+//  Primaries are those specified in Rec. ITU-R BT.709
+//  CIE 1931 chromaticities:  x         y         Y
+//              Red:          0.64      0.33
+//              Green:        0.3       0.6
+//              Blue:         0.15      0.06
+//              White:        0.3127    0.329     100 cd/m^2
+//
+// Display EOTF :
+//  The reference electro-optical transfer function specified in 
+//  IEC 61966-2-1:1999.
+//
+// Signal Range:
+//    This transform outputs full range code values.
+//
+// Assumed observer adapted white point:
+//         CIE 1931 chromaticities:    x            y
+//                                     0.3127       0.329
+//
+// Viewing Environment:
+//   This ODT has a compensation for viewing environment variables more typical 
+//   of those associated with video mastering.
+//
+
+
+
+import "ACESlib.Utilities.a1.0.1";
+import "ACESlib.Transform_Common.a1.0.1";
+import "ACESlib.ODT_Common.a1.0.1";
+import "ACESlib.Tonescales.a1.0.1";
+
+
+
+/* --- ODT Parameters --- */
+const Chromaticities DISPLAY_PRI = REC709_PRI;
+const float XYZ_2_DISPLAY_PRI_MAT[4][4] = XYZtoRGB(DISPLAY_PRI,1.0);
+
+const float DISPGAMMA = 2.4; 
+const float OFFSET = 0.055;
+
+
+
+void main 
+(
+    input varying float rIn, 
+    input varying float gIn, 
+    input varying float bIn, 
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+    float oces[3] = { rIn, gIn, bIn};
+
+  // OCES to RGB rendering space
+    float rgbPre[3] = mult_f3_f44( oces, AP0_2_AP1_MAT);
+
+  // Apply the tonescale independently in rendering-space RGB
+    float rgbPost[3];
+    rgbPost[0] = segmented_spline_c9_fwd( rgbPre[0]);
+    rgbPost[1] = segmented_spline_c9_fwd( rgbPre[1]);
+    rgbPost[2] = segmented_spline_c9_fwd( rgbPre[2]);
+
+  // Scale luminance to linear code value
+    float linearCV[3];
+    linearCV[0] = Y_2_linCV( rgbPost[0], CINEMA_WHITE, CINEMA_BLACK);
+    linearCV[1] = Y_2_linCV( rgbPost[1], CINEMA_WHITE, CINEMA_BLACK);
+    linearCV[2] = Y_2_linCV( rgbPost[2], CINEMA_WHITE, CINEMA_BLACK);    
+
+  // Apply gamma adjustment to compensate for dim surround
+    linearCV = darkSurround_to_dimSurround( linearCV);
+
+  // Apply desaturation to compensate for luminance difference
+    linearCV = mult_f3_f33( linearCV, ODT_SAT_MAT);
+
+  // Convert to display primary encoding
+    // Rendering space RGB to XYZ
+    float XYZ[3] = mult_f3_f44( linearCV, AP1_2_XYZ_MAT);
+
+    // Apply CAT from ACES white point to assumed observer adapted white point
+    XYZ = mult_f3_f33( XYZ, D60_2_D65_CAT);
+
+    // CIE XYZ to display primaries
+    linearCV = mult_f3_f44( XYZ, XYZ_2_DISPLAY_PRI_MAT);
+
+  // Handle out-of-gamut values
+    // Clip values < 0 or > 1 (i.e. projecting outside the display primaries)
+    linearCV = clamp_f3( linearCV, 0., 1.);
+
+  // Encode linear code values with transfer function
+    float outputCV[3];
+    // moncurve_r with gamma of 2.4 and offset of 0.055 matches the EOTF found in IEC 61966-2-1:1999 (sRGB)
+    outputCV[0] = moncurve_r( linearCV[0], DISPGAMMA, OFFSET);
+    outputCV[1] = moncurve_r( linearCV[1], DISPGAMMA, OFFSET);
+    outputCV[2] = moncurve_r( linearCV[2], DISPGAMMA, OFFSET);
+
+    rOut = outputCV[0];
+    gOut = outputCV[1];
+    bOut = outputCV[2];
+    aOut = aIn;
+}


### PR DESCRIPTION
Adds a forward and inverse version of  a "non-D60 sim" RGBmonitor ODT. This brings the supplied RGBmonitor ODTs into alignment with the two versions provided for Rec. 709 - a D65 and a "D60sim in D65" version.

Changes from the existing RGBmonitor ODT:
- add a chromatic adaptation transform from D60 to D65
- remove the small scaling used to allow full D60 simulation

Additionally, the images/README is prepared for the new reference images that will be added to correspond to these new transforms.