### PR TITLE
Updates to ACES documents

### DIFF
--- a/documents/LaTeX/ACES-Document-Manifest/ACES-Document-Manifest.tex
+++ b/documents/LaTeX/ACES-Document-Manifest/ACES-Document-Manifest.tex
@@ -9,43 +9,43 @@
 \regularsectionformat
 
 \section*{ACES Document Manifest}
-Current document versions as of 04/24/2015.
+Current document versions as of 06/08/2016.
 
 \subsection*{Procedures}
-\begin{tabularx}{\linewidth}{|l X|c|c|}
+\begin{tabularx}{\linewidth}{|l X|c|}
 % Document Number | Document Name | Most recent version | Date
 \hline
-\textbf{Document} & & \textbf{Version} & \textbf{Date} \\ \hline
-P-2013-001 & Recommended Procedures for the Creation and Use of Digital Camera System Input Device Transforms (IDTs) & 1.0 & 04/24/15 \\ \hline
+\textbf{Document} & & \textbf{Date Modified} \\ \hline
+P-2013-001 & Recommended Procedures for the Creation and Use of Digital Camera System Input Device Transforms (IDTs) & 03/29/2016 \\ \hline
 \end{tabularx}
 
 \subsection*{Specifications}
-\begin{tabularx}{\linewidth}{|l X|c|c|}
+\begin{tabularx}{\linewidth}{|l X|c|}
 % Document Number | Document Name | Most recent version | Date
 \hline
-\textbf{Document} & & \textbf{Version} & \textbf{Date} \\ \hline
-S-2013-001 & ACESproxy -- An Integer Log Encoding of ACES Image Data & 2.0.2 & 03/11/16 \\ \hline
-S-2014-002 & Academy Color Encoding System -- Versioning System & 1.0.3 & 06/07/16 \\ \hline
-S-2014-003 & ACEScc -- A Logarithmic Encoding of ACES Data for use within Color Grading Systems & 1.0.2 & 09/03/15 \\ \hline
-S-2014-004 & ACEScg -- A Working Space for CGI Render and Compositing & 1.0.1 & 04/24/15 \\ \hline
-S-2014-006 & A Common File Format for Look-Up Tables & 2.0.2 & 09/03/15 \\ \hline
+\textbf{Document} & & \textbf{Date Modified} \\ \hline
+S-2013-001 & ACESproxy -- An Integer Log Encoding of ACES Image Data & 03/29/2016 \\ \hline
+S-2014-002 & Academy Color Encoding System -- Versioning System & 06/07/2016 \\ \hline
+S-2014-003 & ACEScc -- A Logarithmic Encoding of ACES Data for use within Color Grading Systems & 03/29/2016 \\ \hline
+S-2014-004 & ACEScg -- A Working Space for CGI Render and Compositing & 03/29/2016 \\ \hline
+S-2014-006 & A Common File Format for Look-Up Tables & 03/29/2016 \\ \hline
 \end{tabularx}
 
 \subsection*{Technical Bulletins}
-\begin{tabularx}{\linewidth}{|l X|c|c|}
+\begin{tabularx}{\linewidth}{|l X|c|}
 % Document Number | Document Name | Most recent version | Date
 \hline
-\textbf{Document} & & \textbf{Version} & \textbf{Date} \\ \hline
-TB-2014-001 & Academy Color Encoding System (ACES) Documentation Guide & 1.0.1 & 04/24/15 \\ \hline
-TB-2014-002 & Academy Color Encoding System (ACES) Version 1.0 User Experience Guidelines & 1.0.2 & 09/03/15 \\ \hline
-TB-2014-004 & Informative Notes on SMPTE ST 2065-1 -- Academy Color Encoding Specification (ACES) & 1.0.1 & 04/24/15 \\ \hline
-TB-2014-005 & Informative Notes on SMPTE ST 2065-2 -- Academy Printing Density (APD) -- Spectral Responsivities, Reference Measurement Device and Spectral Calculation and SMPTE ST 2065-3 Academy Density Exchange Encoding (ADX) -- Encoding Printing Density (APD) Values & 1.0.1 & 04/24/15 \\ \hline
-TB-2014-006 & Informative Notes on SMPTE ST 2065-4 -- ACES Image Container File Layout & 1.0.1 & 04/24/15 \\ \hline
-TB-2014-007 & Informative Notes on SMPTE ST 268:2014 -- File Format for Digital Moving Picture Exchange (DPX) & 1.0.1 & 04/24/15 \\ \hline
-TB-2014-009 & Academy Color Encoding System (ACES) Clip-level Metadata File Format Definition and Usage & 1.0.1 & 04/24/15 \\ \hline
-TB-2014-010 & Design, Integration and Use of ACES Look Modification Transforms & 1.0.2 & 09/03/15 \\ \hline
-TB-2014-012 & Academy Color Encoding System (ACES) Version 1.0 Component Names & 1.0.1 & 04/24/15 \\ \hline
-TB-2014-013 & Alternate ACES Viewing Pipeline User Experience & 1.0.1 & 04/24/15 \\ \hline
+\textbf{Document} & & \textbf{Date Modified} \\ \hline
+TB-2014-001 & Academy Color Encoding System (ACES) Documentation Guide & 03/29/2016 \\ \hline
+TB-2014-002 & Academy Color Encoding System (ACES) Version 1.0 User Experience Guidelines & 03/29/2016 \\ \hline
+TB-2014-004 & Informative Notes on SMPTE ST 2065-1 -- Academy Color Encoding Specification (ACES) & 03/29/2016 \\ \hline
+TB-2014-005 & Informative Notes on SMPTE ST 2065-2 -- Academy Printing Density (APD) -- Spectral Responsivities, Reference Measurement Device and Spectral Calculation and SMPTE ST 2065-3 Academy Density Exchange Encoding (ADX) -- Encoding Printing Density (APD) Values & 03/29/2016 \\ \hline
+TB-2014-006 & Informative Notes on SMPTE ST 2065-4 -- ACES Image Container File Layout & 03/29/2016 \\ \hline
+TB-2014-007 & Informative Notes on SMPTE ST 268:2014 -- File Format for Digital Moving Picture Exchange (DPX) & 03/29/2016 \\ \hline
+TB-2014-009 & Academy Color Encoding System (ACES) Clip-level Metadata File Format Definition and Usage & 03/29/2016 \\ \hline
+TB-2014-010 & Design, Integration and Use of ACES Look Modification Transforms & 03/29/2016 \\ \hline
+TB-2014-012 & Academy Color Encoding System (ACES) Version 1.0 Component Names & 03/29/2016 \\ \hline
+TB-2014-013 & Alternate ACES Viewing Pipeline User Experience & 03/29/2016 \\ \hline
 \end{tabularx}
 
 \end{document}

--- a/documents/LaTeX/P-2013-001/P-2013-001.tex
+++ b/documents/LaTeX/P-2013-001/P-2013-001.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{P-2013-001}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 In the Academy Color Encoding System, an Input Device Transform (IDT) processes non-color-rendered RGB image values from a digital camera system's capture of a scene lit by an assumed illumination source (the scene adopted white). The results of this process are white-balanced ACES RGB relative exposure values.
 

--- a/documents/LaTeX/P-2013-001/histanddocs.tex
+++ b/documents/LaTeX/P-2013-001/histanddocs.tex
@@ -5,34 +5,13 @@
 
 \begin{tabularx}{\linewidth}{|l|l|X|}
     \hline
-    Version     & 
-    Date        & 
-    Description
-    \\ \hline
-    0.94        & 
-    12/19/2014  & 
-    Recommended Procedures for the Creation and Use of Digital Camera System Input Device Transforms (IDTs)
-    \\ \hline
-    1.0         &
-    04/24/15    &
-    Formatting adjustments and typo fixes
-    \\ \hline
-                &
-                &
-                
-    \\ \hline
-                &
-                &
-                
-    \\ \hline
-                &
-                &
-                
-    \\ \hline
-                &
-                &
-                
-    \\ \hline
+    Version & Date       & Description \\ \hline
+    0.94    & 12/19/2014 & Recommended Procedures for the Creation and Use of Digital Camera System Input Device Transforms (IDTs) \\ \hline
+    1.0     & 04/24/2015 & Formatting adjustments and typo fixes \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
+            & &  \\ \hline
+            & &  \\ \hline
+            & &  \\ \hline
 \end{tabularx}
 
 \vspace{0.25in} % <-- DO NOT REMOVE

--- a/documents/LaTeX/S-2013-001/S-2013-001.tex
+++ b/documents/LaTeX/S-2013-001/S-2013-001.tex
@@ -11,8 +11,7 @@
 \altdocname{ACESproxy -- An Integer Log Encoding of ACES Image Data}
 \docnumber{S-2013-001}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{2.0.2}
-\docdate{March 11, 2016}
+\docdate{March 29, 2016}
 \summary{
 This specification defines integer encoding and decoding functions for the Academy Color Encoding System (ACES). The Academy Color Encoding Specification (ACES) defines a half-precision floating-point color encoding method using a fixed set of RGB primaries. To transport and process ACES compatible images in systems that only support integer data types, this specification defines logarithmic 10-bit and 12-bit integer encodings in a smaller color space known as ACESproxy and specifies functions for conversion of this encoding to and from the floating-point encoding.
 }

--- a/documents/LaTeX/S-2013-001/histanddocs.tex
+++ b/documents/LaTeX/S-2013-001/histanddocs.tex
@@ -11,6 +11,7 @@
     2.0     & 12/19/2014 & Modify ACESproxy primaries, constrain to legal range \\ \hline
     2.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
     2.0.2   & 03/11/2016 & Typo fixes \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
             &      &             \\ \hline
 \end{tabularx}
 

--- a/documents/LaTeX/S-2013-001/specification.tex
+++ b/documents/LaTeX/S-2013-001/specification.tex
@@ -47,7 +47,7 @@ White   & 1.00000 & 1.00000 & 1.00000 & & 0.32168 & 0.33767 \\
 The following functions shall be used to convert between ACES values, encoded according to SMPTE ST 2065-1, and 10-bit integer ACESproxy values.
 
 \subsection{10-bit ACESproxy encoding}
-ACES $R$, $G$, and $B$ values shall be converted to ACESproxyLin $R$, $G$, and $B$ values using the transformation matrix ($TRA$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
+ACES $R$, $G$, and $B$ values shall be converted to ACESproxyLin $R$, $G$, and $B$ values using the transformation matrix ($TRA_{1}$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
 
 ACESproxyLin $R$, $G$, and $B$ values shall be converted to ACESproxy10 values using Equation \ref{eq:ACESproxyLin2ACESproxy10}.
 
@@ -125,7 +125,7 @@ ACESproxy $R$, $G$, and $B$ values shall be converted to ACESproxyLin values usi
 \label{eq:ACESproxy2ACESproxyLin10}
 \end{floatequ}
 
-ACESproxyLin $R$, $G$, and $B$ values shall be converted to ACES $R$, $G$, and $B$ values using the transformation matrix ($TRA$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
+ACESproxyLin $R$, $G$, and $B$ values shall be converted to ACES $R$, $G$, and $B$ values using the transformation matrix ($TRA_{2}$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
 
 \note{Equation \ref{eq:ACESproxyLin2ACES10} shows the relationship between ACES $R$, $G$, and $B$ values and ACESproxyLin $R$, $G$, and $B$ values. $TRA_{2}$, rounded to 10 significant digits, is derived from the product of $NPM_{AP0}$ inverse and $NPM_{AP1}$ calculated using methods provided in Section 3.3 of SMPTE RP 177:1993. AP0 are the primaries of ACES specified in SMPTE ST 2065-1:2012. AP1 are the primaries of ACESproxy specified in \autoref{sec:colorspace}.}
 
@@ -165,7 +165,7 @@ ACESproxyLin $R$, $G$, and $B$ values shall be converted to ACES $R$, $G$, and $
 The following functions shall be used to convert between ACES values, encoded according to SMPTE ST 2065-1, and 12-bit integer ACESproxy values.
 
 \subsection{12-bit ACESproxy encoding}
-ACES $R$, $G$, and $B$ values shall be converted to ACESproxyLin $R$, $G$, and $B$ values using the transformation matrix ($TRA$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
+ACES $R$, $G$, and $B$ values shall be converted to ACESproxyLin $R$, $G$, and $B$ values using the transformation matrix ($TRA_{1}$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
 
 ACESproxyLin $R$, $G$, and $B$ values shall be converted to ACESproxy12 values using Equation \ref{eq:ACESproxyLin2ACESproxy12}.
 
@@ -242,7 +242,7 @@ ACESproxy $R$, $G$, and $B$ values shall be converted to ACESproxyLin values usi
 \label{eq:ACESproxy2ACESproxyLin}
 \end{floatequ}
 
-ACESproxyLin $R$, $G$, and $B$ values shall be converted to ACES $R$, $G$, and $B$ values using the transformation matrix ($TRA$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
+ACESproxyLin $R$, $G$, and $B$ values shall be converted to ACES $R$, $G$, and $B$ values using the transformation matrix ($TRA_{2}$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
 
 \note{Equation \ref{eq:ACESproxyLin2ACES12} shows the relationship between ACES $R$, $G$, and $B$ values and ACESproxyLin $R$, $G$, and $B$ values. $TRA_{2}$, rounded to 10 significant digits, is derived from the product of $NPM_{AP0}$ inverse and $NPM_{AP1}$ calculated using methods provided in Section 3.3 of SMPTE RP 177:1993. AP0 are the primaries of ACES specified in SMPTE ST 2065-1:2012. AP1 are the primaries of ACESproxy specified in \autoref{sec:colorspace}.}
 

--- a/documents/LaTeX/S-2013-001/termsanddefs.tex
+++ b/documents/LaTeX/S-2013-001/termsanddefs.tex
@@ -5,7 +5,7 @@ The following terms and definitions are used in this document.
 %% Modify below this line %%
 
 \term{Academy Color Encoding Specification (ACES)}
-RGB color encoding for exchange of image data that have not been color rendered, between and throughout production and postproduction, within the Academy Color Encoding System. ACES is specified in SMPTE Standard ST 2065-1.
+RGB color encoding for exchange of image data that have not been color rendered, between and throughout production and postproduction, within the Academy Color Encoding System. ACES is specified in SMPTE ST 2065-1.
 
 \term{American Society of Cinematographers Color Decision List (ASC CDL)}
 A set of file formats for the exchange of basic primary color grading information between equipment and software from different manufacturers. ASC CDL provides for Slope, Offset and Power operations applied to each of the red, green and blue channels and for an overall Saturation operation affecting all three.

--- a/documents/LaTeX/S-2014-002/S-2014-002.tex
+++ b/documents/LaTeX/S-2014-002/S-2014-002.tex
@@ -7,8 +7,7 @@
 \altdocname{Academy Color Encoding System -- Versioning System}
 \docnumber{S-2014-002}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.2}
-\docdate{November 11, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document specifies a Versioning System for Academy Color \\*Encoding System components. The purpose of the Versioning System is to provide a means for identifying and managing periodic ACES system releases that will incorporate new features and improvements.
 }

--- a/documents/LaTeX/S-2014-002/histanddocs.tex
+++ b/documents/LaTeX/S-2014-002/histanddocs.tex
@@ -6,10 +6,11 @@
 \begin{tabularx}{\linewidth}{|l|l|X|}
     \hline
     Version & Date & Description \\ \hline
-    1.0     & 12/19/2014     & Initial Version      \\ \hline
-    1.0.1   & 04/24/2015     & Formatting and typo fixes \\ \hline
-    1.0.2   & 11/11/2015     & Add ACESutil as new type  \\ \hline
-    1.0.3   & 06/07/2016     & Changes to naming convention for ACES Core Transforms \\ \hline
+    1.0     & 12/19/2014 & Initial Version      \\ \hline
+    1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
+    1.0.2   & 11/11/2015 & Add ACESutil as new type  \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
+            & 06/07/2016 & Changes to naming convention for ACES Core Transforms \\ \hline
             &      &             \\ \hline
 \end{tabularx}
 

--- a/documents/LaTeX/S-2014-003/S-2014-003.tex
+++ b/documents/LaTeX/S-2014-003/S-2014-003.tex
@@ -7,8 +7,7 @@
 \altdocname{ACEScc -- A Logarithmic Encoding of ACES Data}
 \docnumber{S-2014-003}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.2}
-\docdate{September 3, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document defines a logarithmic encoding of ACES data intended for use in color grading systems whose controls expect a log relationship to relative scene exposures for proper operation. It also uses color primaries closer to achievable display primaries for more natural control with typical color grading tools. This encoding, named ACEScc, provides compatibility with on-set look metadata, particularly ASC CDL, generated using ACESproxy encoding.
 }

--- a/documents/LaTeX/S-2014-003/histanddocs.tex
+++ b/documents/LaTeX/S-2014-003/histanddocs.tex
@@ -6,9 +6,9 @@
 \begin{tabularx}{\linewidth}{|l|l|X|}
     \hline
     Version & Date & Description \\ \hline
-    1.0     & 12/19/2014     & Initial Version      \\ \hline
-    1.0.1   & 04/24/2015     & Formatting and typo fixes \\ \hline
-            &      &             \\ \hline
+    1.0     & 12/19/2014 & Initial Version      \\ \hline
+    1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
             &      &             \\ \hline
             &      &             \\ \hline
 \end{tabularx}

--- a/documents/LaTeX/S-2014-003/specification.tex
+++ b/documents/LaTeX/S-2014-003/specification.tex
@@ -45,7 +45,7 @@ White   & 1.00000 & 1.00000 & 1.00000 & & 0.32168 & 0.33767 \\
 The following functions shall be used to convert between ACES values, encoded according to SMPTE ST 2065-1, and ACEScc.
 
 \subsection{Encoding Function}
-ACES $R$, $G$, and $B$ values shall be converted to ACESccLin $R$, $G$, and $B$ values using the transformation matrix ($TRA$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
+ACES $R$, $G$, and $B$ values shall be converted to ACESccLin $R$, $G$, and $B$ values using the transformation matrix ($TRA_{1}$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
 
 ACESccLin $R$, $G$, and $B$ values shall be converted to ACEScc values using Equation \ref{eq:ACESccLin2ACEScc}.
 

--- a/documents/LaTeX/S-2014-004/S-2014-004.tex
+++ b/documents/LaTeX/S-2014-004/S-2014-004.tex
@@ -7,8 +7,7 @@
 \altdocname{ACEScg -- A Working Space for CGI Render and Compositing}
 \docnumber{S-2014-004}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.1}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document specifies a recommended working space for CGI render and compositing to be used in conjunction with the ACES system.
 }

--- a/documents/LaTeX/S-2014-004/histanddocs.tex
+++ b/documents/LaTeX/S-2014-004/histanddocs.tex
@@ -6,9 +6,9 @@
 \begin{tabularx}{\linewidth}{|l|l|X|}
     \hline
     Version & Date & Description \\ \hline
-    1.0     & 12/19/2014     & Initial Version      \\ \hline
-    1.0.1   & 04/24/2015     & Formatting and typo fixes \\ \hline
-            &      &             \\ \hline
+    1.0     & 12/19/2014 & Initial Version      \\ \hline
+    1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
             &      &             \\ \hline
             &      &             \\ \hline
 \end{tabularx}

--- a/documents/LaTeX/S-2014-004/specification.tex
+++ b/documents/LaTeX/S-2014-004/specification.tex
@@ -63,7 +63,7 @@ The following functions shall be used to convert between ACES values, encoded ac
 
 \subsection{Converting ACES2065-1 RGB values to ACEScg RGB values}
 \label{sec:aces2acescg}
-ACES $R$, $G$, and $B$ values shall be converted to ACEScg $R$, $G$, and $B$ values using the transformation matrix ($TRA$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
+ACES $R$, $G$, and $B$ values shall be converted to ACEScg $R$, $G$, and $B$ values using the transformation matrix ($TRA_{1}$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
 
 \note{Equation \ref{eq:aces2acescg} shows the relationship between ACES $R$, $G$, and $B$ values and ACEScg $R$, $G$, and $B$ values. $TRA_{1}$, rounded to 10 significant digits, is derived from the product of $NPM_{AP1}$ inverse and $NPM_{AP0}$ calculated using methods provided in Section 3.3 of SMPTE RP 177:1993. AP0 are the primaries of ACES specified in SMPTE ST 2065-1:2012. AP1 are the primaries of ACEScg specified in \autoref{sec:colorspace}.}
 
@@ -97,7 +97,7 @@ ACES $R$, $G$, and $B$ values shall be converted to ACEScg $R$, $G$, and $B$ val
 \end{floatequ}
 
 \subsection{Converting ACEScg RGB values to ACES2065-1 RGB values}
-ACEScg $R$, $G$, and $B$ values shall be converted to ACES2065-1 $R$, $G$ and $B$ using the transformation matrix ($TRA$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
+ACEScg $R$, $G$, and $B$ values shall be converted to ACES2065-1 $R$, $G$ and $B$ using the transformation matrix ($TRA_{2}$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
 
 \note{Equation \ref{eq:acescg2aces} shows the relationship between ACES $R$, $G$, and $B$ values and ACEScg $R$, $G$, and $B$ values. $TRA_{2}$, rounded to 10 significant digits, is derived from the product of $NPM_{AP0}$ inverse and $NPM_{AP1}$ calculated using methods provided in Section 3.3 of SMPTE RP 177:1993. AP0 are the primaries of ACES specified in SMPTE ST 2065-1:2012. AP1 are the primaries of ACEScg specified in \autoref{sec:colorspace}.}
 

--- a/documents/LaTeX/S-2014-006/S-2014-006.tex
+++ b/documents/LaTeX/S-2014-006/S-2014-006.tex
@@ -17,8 +17,7 @@
 \altdocname{A Common File Format for Look-Up Tables}
 \docnumber{S-2014-006}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{2.0.2}
-\docdate{September 3, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document introduces a human-readable text file format for the interchange of color transformations using an XML schema. The XML format supports Look-Up Tables of several types: 1D LUTs, 3D LUTs, and 3by1D LUTs, as well as additional transformation needs such as matrices, range rescaling, and `shaper LUTs'. The document defines a processing model for color transformations where each transformation is defined by a `Node' that operates upon a stream of image pixels. A node contains the data for a transformation, and a sequence of nodes can be specified in which the output of one transform feeds into the input of another node. The XML representation allows saving in a text file both a chain of multiple nodes or a single node representing a unique transform. The format is extensible and self-contained so the XML file may be used as an archival element.
 }

--- a/documents/LaTeX/S-2014-006/histanddocs.tex
+++ b/documents/LaTeX/S-2014-006/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 05/11/2008 & Academy-ASC Common LUT Format, Version 1.0      \\ \hline
     2.0     & 12/19/2014 & Roll-up of ACES LUT Task Force comments \\ \hline
     2.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-            &      &             \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
             &      &             \\ \hline
 \end{tabularx}
 

--- a/documents/LaTeX/TB-2014-001/TB-2014-001.tex
+++ b/documents/LaTeX/TB-2014-001/TB-2014-001.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-001}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.1}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document describes the technical documentation provided with ACES System Release.
 }

--- a/documents/LaTeX/TB-2014-001/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-001/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline

--- a/documents/LaTeX/TB-2014-002/TB-2014-002.tex
+++ b/documents/LaTeX/TB-2014-002/TB-2014-002.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-002}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.2}
-\docdate{September 3, 2015}
+\docdate{March 29, 2016}
 \summary{
 The Academy Color Encoding System (ACES) is the industry standard for managing color throughout the life-cycle of a motion picture or television production (from creation, thru editorial, grading, audience presentation, and archiving).
 

--- a/documents/LaTeX/TB-2014-002/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-002/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline

--- a/documents/LaTeX/TB-2014-004/TB-2014-004.tex
+++ b/documents/LaTeX/TB-2014-004/TB-2014-004.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-004}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.1}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document provides notes on SMPTE Standard 2065-1 -- Academy Color Encoding Specification (ACES).
 }

--- a/documents/LaTeX/TB-2014-004/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-004/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline

--- a/documents/LaTeX/TB-2014-005/TB-2014-005.tex
+++ b/documents/LaTeX/TB-2014-005/TB-2014-005.tex
@@ -10,8 +10,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-005}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.1}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document provides notes on SMPTE ST 2065-2 Academy Printing Density (APD) -- Spectral Responsivities, Reference Measurement Device and Spectral Calculation and SMPTE ST 2065-3 Academy Density Exchange Encoding (ADX) -- Encoding Academy Printing Density (APD) Values.
 }

--- a/documents/LaTeX/TB-2014-005/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-005/histanddocs.tex
@@ -9,8 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
 \end{tabularx}

--- a/documents/LaTeX/TB-2014-006/TB-2014-006.tex
+++ b/documents/LaTeX/TB-2014-006/TB-2014-006.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-006}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.1}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document provides notes on SMPTE ST 2065-4 -- ACES Image Container File Layout.
 }

--- a/documents/LaTeX/TB-2014-006/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-006/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline

--- a/documents/LaTeX/TB-2014-007/TB-2014-007.tex
+++ b/documents/LaTeX/TB-2014-007/TB-2014-007.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-007}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.1}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document provides notes on SMPTE ST 268:2014 -- File Format for Digital Moving Picture Exchange (DPX).
 }

--- a/documents/LaTeX/TB-2014-007/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-007/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline

--- a/documents/LaTeX/TB-2014-009/TB-2014-009.tex
+++ b/documents/LaTeX/TB-2014-009/TB-2014-009.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-009}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.1}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 The ACES Clip-level Metadata File (``ACESclip'') is a `sidecar' XML file intended to assist in configuring ACES viewing pipelines and to enable portability of ACES transforms in production. This document specifies use cases for ACESclip files, application support requirements, and the data model and XML tags needed for implementation.
 }

--- a/documents/LaTeX/TB-2014-009/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-009/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline

--- a/documents/LaTeX/TB-2014-009/sec-datamodel.tex
+++ b/documents/LaTeX/TB-2014-009/sec-datamodel.tex
@@ -96,7 +96,7 @@ This section is for optional user-defined metadata.  Customized information may 
 \texttt{</aces:Info>}
 
 \section{Carriage of XML-based Color Transform Files}
-The Transform Library is intended to provide a portable mechanism for transforms, particularly those listed in the aces:Config.  Transforms may take the form of a CDL or a Common LUT Format ProcessList. (A CTL implementation is provided for reference, but production support of CTL files is not currently required).
+The Transform Library is intended to provide a portable mechanism for transforms, particularly those listed in the \textit{aces:Config}.  Transforms may take the form of a CDL or a Common LUT Format ProcessList. (A CTL implementation is provided for reference, but production support of CTL files is not currently required).
 
 Each transform in this section is required to have an {id} attribute for reference from the ACESconfig.
 
@@ -112,6 +112,6 @@ If transforms are not present in the file, they must be made available through s
     \tabto{6em}\texttt{<!}[CDATA[CTL FILE ----\\
     \tabto{6.1em}***** include .ctl file *****\\
     \tabto{6em}]]\texttt{>}\par
-	\tabto{4em}\texttt{</CTL file} \{name\}
+	\tabto{4em}\texttt{</CTL file} \{name\}\texttt{>}
 	
 \texttt{</aces:Transform\_Library>}

--- a/documents/LaTeX/TB-2014-010/TB-2014-010.tex
+++ b/documents/LaTeX/TB-2014-010/TB-2014-010.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-010}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.2}
-\docdate{September 3, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document describes a component of the ACES viewing pipeline, the Look Modification Transform (LMT). The LMT precedes the sequential application of the ACES Reference Rendering Transform (RRT) and a particular Output Device Transform (ODT), and allows custom and systematic color changes to a set of clips to realize a chosen creative intent. In a workflow built around ACES-based color management, these changes can be limited to paths to a display (a `nondestructive' color change) or they can be used to produce new ACES image files (`baking in' the color changes).
 

--- a/documents/LaTeX/TB-2014-010/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-010/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline

--- a/documents/LaTeX/TB-2014-012/TB-2014-012.tex
+++ b/documents/LaTeX/TB-2014-012/TB-2014-012.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-012}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.1}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 This document lists Academy Color Encoding System (ACES) technical component names adopted for Version 1.0. This document was developed to eliminate confusion regarding ACES component names from both engineering and user perspectives.
 }

--- a/documents/LaTeX/TB-2014-012/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-012/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline

--- a/documents/LaTeX/TB-2014-013/TB-2014-013.tex
+++ b/documents/LaTeX/TB-2014-013/TB-2014-013.tex
@@ -8,8 +8,7 @@
 % Sets the document name used in header - usually an abbreviated document title
 \docnumber{TB-2014-013}
 \committeename{Academy Color Encoding System (ACES) Project Committee}
-\versionnumber{1.0.1}
-\docdate{April 24, 2015}
+\docdate{March 29, 2016}
 \summary{
 The majority of products that implemented pre-release ACES adopted an approach that combined the RRT and ODT into a single transform. It may useful to have one transform that has both ACES rendering components (from the RRT and ODT) that outputs the desired display colorimetry followed by a simple transform that converts that colorimetry into display code values. The ACES User Experience Working Group is developing an alternate UX proposal for products that wish to structure their viewing pipeline using this approach. This work is put forward for consideration as a possible recommended approach for a future ACES release.
 }

--- a/documents/LaTeX/TB-2014-013/histanddocs.tex
+++ b/documents/LaTeX/TB-2014-013/histanddocs.tex
@@ -9,7 +9,7 @@
     1.0     & 12/19/2014 & Initial Version
     \\ \hline
     1.0.1   & 04/24/2015 & Formatting and typo fixes \\ \hline
-    &   &   \\ \hline
+            & 03/29/2016 & Remove version number - to use modification date as UID \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline
     &   &   \\ \hline

--- a/documents/LaTeX/template/AcademyDoc.cls
+++ b/documents/LaTeX/template/AcademyDoc.cls
@@ -136,10 +136,9 @@
 \fancypagestyle{plain}{%
   \fancyhf{} % clear all six fields
   \fancyhead[L]{\Docnumber}
-  \fancyhead[C]{\Altdocname}
-  \fancyhead[R]{Page \thepage}
-  \fancyfoot[L]{Version \Versionnumber}
-  \fancyfoot[R]{\Docdate }
+  \fancyhead[R]{\Altdocname}
+  \fancyfoot[L]{Page \thepage}
+  \fancyfoot[R]{\Docdate}
   \renewcommand{\headrulewidth}{0pt}
   \renewcommand{\footrulewidth}{0pt}
 }
@@ -323,7 +322,7 @@
 		\vspace{22pt}
 		\fontsize{11}{13.2} 
 		\selectfont
-		Version \Versionnumber \hspace{0.25 in} \Docdate \\
+		\Docdate \\
 		\vspace{18pt}
 	\end{center}
 	\begin{adjustwidth}{0.5in}{0.5in}


### PR DESCRIPTION
The main change here is that the document version numbers are removed in favor of simply using the document modification date as the unique version identifier. Having a 'date modified' _and_ 'version' is unnecessarily cumbersome. Furthermore, some users of the documents have expressed confusion of the document version numbers in relation to the ACES core transform versioning scheme. To remove this confusion, documents version numbers are removed and the document manifest is updated accordingly.

Also included are a few minor typo/formatting fixes - e.g. missing subscripts for the TRA transformation matrix referenced in ACEScc, ACEScg, and ACESproxy docs as well as erroneous typesetting in ACESclip doc.