### PR TITLE
Add missing D65 to D60 CAT to InvODT.Academy.P3DCI_D65sim_48nits.ctl

### DIFF
--- a/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D65sim_48nits.ctl
+++ b/transforms/ctl/odt/p3/InvODT.Academy.P3DCI_D65sim_48nits.ctl
@@ -49,6 +49,9 @@ void main
     // Display primaries to CIE XYZ
     float XYZ[3] = mult_f3_f44( linearCV, DISPLAY_PRI_2_XYZ_MAT);
 
+    // Apply CAT from assumed observer adapted white to ACES white point
+    XYZ = mult_f3_f33( XYZ, invert_f33( D60_2_D65_CAT));
+
     // CIE XYZ to rendering space RGB
     linearCV = mult_f3_f44( XYZ, XYZ_2_AP1_MAT);
 


### PR DESCRIPTION
Add the inverse of the D60 to D65 chromatic adaptation, so the transform correctly inverts the forward ODT.

References #110