### PR TITLE
PR: Add minimal descriptions to CSC transforms.

### DIFF
--- a/transforms/ctl/csc/arri/ACEScsc.Academy.ACES_to_LogC_EI800_AWG.ctl
+++ b/transforms/ctl/csc/arri/ACEScsc.Academy.ACES_to_LogC_EI800_AWG.ctl
@@ -1,6 +1,14 @@
 
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_LogC_EI800_AWG.a1.1.0</ACEStransformID>
-// <ACESuserName>ACES2065-1 to ARRI LogC EI800 AWG</ACESuserName>
+// <ACESuserName>ACES2065-1 to ARRI LogC EI800 ALEXA Wide Gamut</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES to ARRI LogC EI800 ALEXA Wide Gamut
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          ARRI LogC EI800 ALEXA Wide Gamut
+//
+
 
 
 import "ACESlib.Utilities_Color";

--- a/transforms/ctl/csc/arri/ACEScsc.Academy.LogC_EI800_AWG_to_ACES.ctl
+++ b/transforms/ctl/csc/arri/ACEScsc.Academy.LogC_EI800_AWG_to_ACES.ctl
@@ -1,6 +1,14 @@
 
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.LogC_EI800_AWG_to_ACES.a1.1.0</ACEStransformID>
-// <ACESuserName>ARRI LogC EI800 AWG to ACES2065-1</ACESuserName>
+// <ACESuserName>ARRI LogC EI800 ALEXA Wide Gamut to ACES2065-1</ACESuserName>
+
+//
+// ACES Color Space Conversion - ARRI LogC EI800 ALEXA Wide Gamut to ACES
+//
+// converts ARRI LogC EI800 ALEXA Wide Gamut to
+//          ACES2065-1 (AP0 w/ linear encoding)
+//
+
 
 
 import "ACESlib.Utilities_Color";

--- a/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog2_CGamut.ctl
+++ b/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog2_CGamut.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog2_CGamut.a1.1.0</ACEStransformID>
 // <ACESuserName>ACES2065-1 to Canon Log 2 Cinema Gamut</ACESuserName>
 
+//
+// ACES Color Space Conversion - ACES to Canon Log 2 Cinema Gamut
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Canon Log 2 Cinema Gamut
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog3_CGamut.ctl
+++ b/transforms/ctl/csc/canon/ACEScsc.Academy.ACES_to_CLog3_CGamut.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog3_CGamut.a1.1.0</ACEStransformID>
 // <ACESuserName>ACES2065-1 to Canon Log 3 Cinema Gamut</ACESuserName>
 
+//
+// ACES Color Space Conversion - ACES to Canon Log 3 Cinema Gamut
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Canon Log 3 Cinema Gamut
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/canon/ACEScsc.Academy.CLog2_CGamut_to_ACES.ctl
+++ b/transforms/ctl/csc/canon/ACEScsc.Academy.CLog2_CGamut_to_ACES.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog2_CGamut_to_ACES.a1.1.0</ACEStransformID>
 // <ACESuserName>Canon Log 2 Cinema Gamut to ACES2065-1</ACESuserName>
 
+//
+// ACES Color Space Conversion - Canon Log 2 Cinema Gamut to ACES
+//
+// converts Canon Log 2 Cinema Gamut to
+//          ACES2065-1 (AP0 w/ linear encoding)
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/canon/ACEScsc.Academy.CLog3_CGamut_to_ACES.ctl
+++ b/transforms/ctl/csc/canon/ACEScsc.Academy.CLog3_CGamut_to_ACES.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog3_CGamut_to_ACES.a1.1.0</ACEStransformID>
 // <ACESuserName>Canon Log 3 Cinema Gamut to ACES2065-1</ACESuserName>
 
+//
+// ACES Color Space Conversion - Canon Log 3 Cinema Gamut to ACES
+//
+// converts Canon Log 3 Cinema Gamut to
+//          ACES2065-1 (AP0 w/ linear encoding)
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/panasonic/ACEScsc.Academy.ACES_to_VLog_VGamut.ctl
+++ b/transforms/ctl/csc/panasonic/ACEScsc.Academy.ACES_to_VLog_VGamut.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_VLog_VGamut.a1.1.0</ACEStransformID>
 // <ACESuserName>ACES2065-1 to Panasonic Varicam V-Log V-Gamut</ACESuserName>
 
+//
+// ACES Color Space Conversion - ACES to Panasonic Varicam V-Log V-Gamut
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Panasonic Varicam V-Log V-Gamut
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/panasonic/ACEScsc.Academy.VLog_VGamut_to_ACES.ctl
+++ b/transforms/ctl/csc/panasonic/ACEScsc.Academy.VLog_VGamut_to_ACES.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.VLog_VGamut_to_ACES.a1.1.0</ACEStransformID>
 // <ACESuserName>Panasonic Varicam V-Log V-Gamut to ACES2065-1</ACESuserName>
 
+//
+// ACES Color Space Conversion - Panasonic Varicam V-Log V-Gamut to ACES
+//
+// converts Panasonic Varicam V-Log V-Gamut to
+//          ACES2065-1 (AP0 w/ linear encoding)
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/red/ACEScsc.Academy.ACES_to_Log3G10_RWG.ctl
+++ b/transforms/ctl/csc/red/ACEScsc.Academy.ACES_to_Log3G10_RWG.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_Log3G10_RWG.a1.1.0</ACEStransformID>
 // <ACESuserName>ACES2065-1 to RED Log3G10 REDWideGamutRGB</ACESuserName>
 
+//
+// ACES Color Space Conversion - ACES to RED Log3G10 REDWideGamutRGB
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          RED Log3G10 REDWideGamutRGB
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/red/ACEScsc.Academy.Log3G10_RWG_to_ACES.ctl
+++ b/transforms/ctl/csc/red/ACEScsc.Academy.Log3G10_RWG_to_ACES.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.Log3G10_RWG_to_ACES.a1.1.0</ACEStransformID>
 // <ACESuserName>RED Log3G10 REDWideGamutRGB to ACES2065-1</ACESuserName>
 
+//
+// ACES Color Space Conversion - RED Log3G10 REDWideGamutRGB to ACES
+//
+// converts RED Log3G10 REDWideGamutRGB to
+//          ACES2065-1 (AP0 w/ linear encoding)
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3.ctl
+++ b/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3.a1.1.0</ACEStransformID>
 // <ACESuserName>ACES2065-1 to Sony S-Log3 S-Gamut3</ACESuserName>
 
+//
+// ACES Color Space Conversion - ACES to Sony S-Log3 S-Gamut3
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Sony S-Log3 S-Gamut3
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.ctl
+++ b/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.ctl
@@ -2,6 +2,15 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.a1.1.0</ACEStransformID>
 // <ACESuserName>ACES2065-1 to Sony S-Log3 S-Gamut3.Cine</ACESuserName>
 
+//
+// ACES Color Space Conversion - ACES to Sony S-Log3 S-Gamut3.Cine
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Sony S-Log3 S-Gamut3.Cine
+//
+
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.ctl
+++ b/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.a1.1.0</ACEStransformID>
 // <ACESuserName>Sony S-Log3 S-Gamut3.Cine to ACES2065-1</ACESuserName>
 
+//
+// ACES Color Space Conversion - Sony S-Log3 S-Gamut3.Cine to ACES
+//
+// converts Sony S-Log3 S-Gamut3.Cine to
+//          ACES2065-1 (AP0 w/ linear encoding)
+//
+
+
 
 import "ACESlib.Utilities_Color";
 

--- a/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3_to_ACES.ctl
+++ b/transforms/ctl/csc/sony/ACEScsc.Academy.SLog3_SGamut3_to_ACES.ctl
@@ -2,6 +2,14 @@
 // <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3_to_ACES.a1.1.0</ACEStransformID>
 // <ACESuserName>Sony S-Log3 S-Gamut3 to ACES2065-1</ACESuserName>
 
+//
+// ACES Color Space Conversion - Sony S-Log3 S-Gamut3 to ACES
+//
+// converts Sony S-Log3 S-Gamut3 to
+//          ACES2065-1 (AP0 w/ linear encoding)
+//
+
+
 
 import "ACESlib.Utilities_Color";
 


### PR DESCRIPTION
This PR adds minimal descriptions to the CSC transforms.

Everything should be straightforward besides a minor tweak to the `ACESuserName` for the ARRI transforms where I changed _AWG_ to _ALEXA Wide Gamut_ for consistency.