### PR TITLE
PR: Add "Sony VENICE SGamut3" and "Sony VENICE SGamut3.Cine" CSC transforms.

### DIFF
--- a/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_Venice_SLog3_SGamut3.ctl
+++ b/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_Venice_SLog3_SGamut3.ctl
@@ -1,0 +1,59 @@
+
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3.a1.1.0</ACEStransformID>
+// <ACESuserName>ACES2065-1 to Sony S-Log3 VENICE S-Gamut3</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES to Sony S-Log3 VENICE S-Gamut3
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Sony S-Log3 VENICE S-Gamut3
+//
+
+
+
+import "ACESlib.Utilities_Color";
+
+
+const float AP0_2_VENICE_SGAMUT3_MAT[3][3] =
+                        calculate_rgb_to_rgb_matrix( AP0, 
+                                                     SONY_VENICE_SGAMUT3_PRI,
+                                                     CONE_RESP_MAT_CAT02);
+
+
+float lin_to_SLog3( input varying float in)
+{
+    float out;
+    if ( in >= 0.01125000 )
+    {
+        out = (420.0 + log10((in + 0.01) / (0.18 + 0.01)) * 261.5) / 1023.0;
+    }
+    else
+    {
+        out = (in * (171.2102946929 - 95.0) / 0.01125000 + 95.0) / 1023.0;
+    }
+    return out;
+}
+
+
+
+void main
+(   
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+    float ACES[3] = { rIn, gIn, bIn};
+
+    float lin_SGamut3[3] = mult_f3_f33( ACES, AP0_2_VENICE_SGAMUT3_MAT);
+
+    rOut = lin_to_SLog3( lin_SGamut3[0]);
+    gOut = lin_to_SLog3( lin_SGamut3[1]);
+    bOut = lin_to_SLog3( lin_SGamut3[2]);
+    aOut = aIn;
+}

--- a/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_Venice_SLog3_SGamut3Cine.ctl
+++ b/transforms/ctl/csc/sony/ACEScsc.Academy.ACES_to_Venice_SLog3_SGamut3Cine.ctl
@@ -1,0 +1,60 @@
+
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3Cine.a1.1.0</ACEStransformID>
+// <ACESuserName>ACES2065-1 to Sony S-Log3 VENICE S-Gamut3.Cine</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES to Sony S-Log3 VENICE S-Gamut3.Cine
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Sony S-Log3 VENICE S-Gamut3.Cine
+//
+
+
+
+
+import "ACESlib.Utilities_Color";
+
+
+const float AP0_2_VENICE_SGAMUT3_CINE_MAT[3][3] =
+                        calculate_rgb_to_rgb_matrix( AP0, 
+                                                     SONY_VENICE_SGAMUT3_CINE_PRI,
+                                                     CONE_RESP_MAT_CAT02);
+
+
+float lin_to_SLog3( input varying float in)
+{
+    float out;
+    if ( in >= 0.01125000 )
+    {
+        out = (420.0 + log10((in + 0.01) / (0.18 + 0.01)) * 261.5) / 1023.0;
+    }
+    else
+    {
+        out = (in * (171.2102946929 - 95.0) / 0.01125000 + 95.0) / 1023.0;
+    }
+    return out;
+}
+
+
+
+void main
+(   
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+    float ACES[3] = { rIn, gIn, bIn};
+
+    float lin_SGamut3Cine[3] = mult_f3_f33( ACES, AP0_2_VENICE_SGAMUT3_CINE_MAT);
+
+    rOut = lin_to_SLog3( lin_SGamut3Cine[0]);
+    gOut = lin_to_SLog3( lin_SGamut3Cine[1]);
+    bOut = lin_to_SLog3( lin_SGamut3Cine[2]);
+    aOut = aIn;
+}

--- a/transforms/ctl/csc/sony/ACEScsc.Academy.Venice_SLog3_SGamut3Cine_to_ACES.ctl
+++ b/transforms/ctl/csc/sony/ACEScsc.Academy.Venice_SLog3_SGamut3Cine_to_ACES.ctl
@@ -1,0 +1,62 @@
+
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3Cine_to_ACES.a1.1.0</ACEStransformID>
+// <ACESuserName>Sony S-Log3 VENICE S-Gamut3.Cine to ACES2065-1</ACESuserName>
+
+//
+// ACES Color Space Conversion - Sony S-Log3 VENICE S-Gamut3.Cine to ACES
+//
+// converts Sony S-Log3 VENICE S-Gamut3.Cine to
+//          ACES2065-1 (AP0 w/ linear encoding)
+//
+
+
+
+import "ACESlib.Utilities_Color";
+
+
+const float VENICE_SGAMUT3_CINE_2_AP0_MAT[3][3] =
+                        calculate_rgb_to_rgb_matrix( SONY_VENICE_SGAMUT3_CINE_PRI,
+                                                     AP0, 
+                                                     CONE_RESP_MAT_CAT02);
+
+
+float SLog3_to_lin( input varying float in)
+{
+    float out;
+    if ( in >= 171.2102946929 / 1023.0 )
+    {
+        out = pow(10.0, (in * 1023.0 - 420.0) / 261.5) * (0.18 + 0.01) - 0.01;
+    }
+    else
+    {
+        out = (in * 1023.0 - 95.0) * 0.01125000 / (171.2102946929 - 95.0);
+    }
+    return out;
+}
+
+
+
+void main
+(   
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+    float lin_SGamut3Cine[3];
+    lin_SGamut3Cine[0] = SLog3_to_lin( rIn);
+    lin_SGamut3Cine[1] = SLog3_to_lin( gIn);
+    lin_SGamut3Cine[2] = SLog3_to_lin( bIn);
+
+    float ACES[3] = mult_f3_f33( lin_SGamut3Cine, VENICE_SGAMUT3_CINE_2_AP0_MAT);
+  
+    rOut = ACES[0];
+    gOut = ACES[1];
+    bOut = ACES[2];
+    aOut = aIn;
+}

--- a/transforms/ctl/csc/sony/ACEScsc.Academy.Venice_SLog3_SGamut3_to_ACES.ctl
+++ b/transforms/ctl/csc/sony/ACEScsc.Academy.Venice_SLog3_SGamut3_to_ACES.ctl
@@ -1,0 +1,62 @@
+
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3_to_ACES.a1.1.0</ACEStransformID>
+// <ACESuserName>Sony S-Log3 VENICE S-Gamut3 to ACES2065-1</ACESuserName>
+
+//
+// ACES Color Space Conversion - Sony S-Log3 VENICE S-Gamut3 to ACES
+//
+// converts Sony S-Log3 VENICE S-Gamut3 to
+//          ACES2065-1 (AP0 w/ linear encoding)
+//
+
+
+
+import "ACESlib.Utilities_Color";
+
+
+const float VENICE_SGAMUT3_2_AP0_MAT[3][3] =
+                        calculate_rgb_to_rgb_matrix( SONY_VENICE_SGAMUT3_PRI,
+                                                     AP0, 
+                                                     CONE_RESP_MAT_CAT02);
+
+
+float SLog3_to_lin( input varying float in)
+{
+    float out;
+    if ( in >= 171.2102946929 / 1023.0 )
+    {
+        out = pow(10.0, (in * 1023.0 - 420.0) / 261.5) * (0.18 + 0.01) - 0.01;
+    }
+    else
+    {
+        out = (in * 1023.0 - 95.0) * 0.01125000 / (171.2102946929 - 95.0);
+    }
+    return out;
+}
+
+
+
+void main
+(   
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+    float lin_SGamut3[3];
+    lin_SGamut3[0] = SLog3_to_lin( rIn);
+    lin_SGamut3[1] = SLog3_to_lin( gIn);
+    lin_SGamut3[2] = SLog3_to_lin( bIn);
+
+    float ACES[3] = mult_f3_f33( lin_SGamut3, VENICE_SGAMUT3_2_AP0_MAT);
+  
+    rOut = ACES[0];
+    gOut = ACES[1];
+    bOut = ACES[2];
+    aOut = aIn;
+}

--- a/transforms/ctl/lib/ACESlib.Utilities_Color.ctl
+++ b/transforms/ctl/lib/ACESlib.Utilities_Color.ctl
@@ -102,6 +102,25 @@ const Chromaticities SONY_SGAMUT3_CINE_PRI =
   { 0.3127,  0.3290}
 };
 
+// Note: No official published primaries exist as of this day for the
+// Sony VENICE SGamut3 and Sony VENICE SGamut3.Cine colorspaces. The primaries
+// have thus been derived from the IDT matrices.
+const Chromaticities SONY_VENICE_SGAMUT3_PRI =
+{
+  { 0.740464264304292,  0.279364374750660},
+  { 0.089241145423286,  0.893809528608105},
+  { 0.110488236673827, -0.052579333080476},
+  { 0.312700000000000,  0.329000000000000}
+};
+
+const Chromaticities SONY_VENICE_SGAMUT3_CINE_PRI =
+{
+  { 0.775901871567345,  0.274502392854799},
+  { 0.188682902773355,  0.828684937020288},
+  { 0.101337382499301, -0.089187517306263},
+  { 0.312700000000000,  0.329000000000000}
+};
+
 const Chromaticities CANON_CGAMUT_PRI =
 {
   { 0.7400,  0.2700},


### PR DESCRIPTION
This PR adds the two following CSC transforms for consistency purposes:

- Sony VENICE SGamut3
- Sony VENICE SGamut3.Cine

The primaries have been derived as follows: https://colab.research.google.com/drive/1ZGTij7jT8eZRMPUkyWlv_x5ix5Q5twMB?usp=sharing

Note that I haven't checked yet if the transforms are behaving correctly.