### PR TITLE
Change Gamut Compress to Reference Gamut Compress

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -75,7 +75,7 @@ ACEScc and ACESproxy image data is **NOT** intended to be written out to image f
     * *SonyF35.StillLife_from_Venice_SLog3_SGamut3Cine.exr* - `ACEScsc.Academy.Venice_SLog3_SGamut3Cine_to_ACES.ctl` applied to *ACEScsc/SonyF35.StillLife_Venice_SLog3_SGamut3Cine.exr*
     * *SonyF35.StillLife_from_VLog_VGamut_.exr* - `ACEScsc.Academy.VLog_VGamut_to_ACES.ctl` applied to *ACEScsc/SonyF35.StillLife_VLog_VGamut.exr*
     * *SonyF35.StillLife_from_InvRRT.exr* - `InvRRT.ctl` applied to *OCES/SonyF35.StillLife.exr*
-    * *SonyF35.StillLife_from_LMT.Academy.GamutCompress.exr* - `LMT.Academy.GamutCompress.ctl` applied with `invert = true` to *LMT/SonyF35.StillLife_LMT.Academy.GamutCompress.exr*
+    * *SonyF35.StillLife_from_LMT.Academy.ReferenceGamutCompress.exr* - `InvLMT.Academy.ReferenceGamutCompress.ctl` applied to *LMT/SonyF35.StillLife_LMT.Academy.ReferenceGamutCompress.exr*
     * *SonyF35.StillLife_from_RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.tiff* - `InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl` applied to *RRTODT/SonyF35.StillLife_RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.tiff**
     * *SonyF35.StillLife_from_RRTODT.Academy.Rec2020_1000nits_15nits_HLG.tiff* - `InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl` applied to *RRTODT/SonyF35.StillLife_RRTODT.Academy.Rec2020_1000nits_15nits_HLG.tiff**
     * *SonyF35.StillLife_from_RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.tiff* - `InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl` applied to *RRTODT/SonyF35.StillLife_RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.tiff**
@@ -96,7 +96,7 @@ ACEScc and ACESproxy image data is **NOT** intended to be written out to image f
     * *syntheticChart.01_from_Venice_SLog3_SGamut3Cine.exr* - `ACEScsc.Academy.Venice_SLog3_SGamut3Cine_to_ACES.ctl` applied to *ACEScsc/syntheticChart.01_Venice_SLog3_SGamut3Cine.exr*
     * *syntheticChart.01_from_VLog_VGamut.exr* - `ACEScsc.Academy.VLog_VGamut_to_ACES.ctl` applied to *ACEScsc/syntheticChart.01_VLog_VGamut.exr*
     * *syntheticChart.01_from_InvRRT.exr* - `InvRRT.ctl` applied to *OCES/syntheticChart.01.exr*
-    * *syntheticChart.01_from_LMT.Academy.GamutCompress.exr* - `LMT.Academy.GamutCompress.ctl` applied with `invert = true` to *LMT/syntheticChart.01_LMT.Academy.GamutCompress.exr*
+    * *syntheticChart.01_from_LMT.Academy.ReferenceGamutCompress.exr* - `InvLMT.Academy.ReferenceGamutCompress.ctl` applied to *LMT/syntheticChart.01_LMT.Academy.ReferenceGamutCompress.exr*
     * *syntheticChart.01_from_RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.tiff* - `InvRRTODT.Academy.P3D65_108nits_7.2nits_ST2084.ctl` applied to *RRTODT/syntheticChart.01_RRTODT.Academy.P3D65_108nits_7.2nits_ST2084.tiff**
     * *syntheticChart.01_from_RRTODT.Academy.Rec2020_1000nits_15nits_HLG.tiff* - `InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.ctl` applied to *RRTODT/syntheticChart.01_RRTODT.Academy.Rec2020_1000nits_15nits_HLG.tiff**
     * *syntheticChart.01_from_RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.tiff* - `InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.ctl` applied to *RRTODT/syntheticChart.01_RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.tiff**
@@ -140,12 +140,12 @@ ACEScc and ACESproxy image data is **NOT** intended to be written out to image f
     * *SonyF35.StillLife_LMT.Academy.ACES_0_2_2.exr* - `LMT.Academy.ACES_0_2_2.ctl` applied to *ACES/SonyF35.StillLife.exr*
     * *SonyF35.StillLife_LMT.Academy.ACES_0_7_1.exr* - `LMT.Academy.ACES_0_7_1.ctl` applied to *ACES/SonyF35.StillLife.exr*
     * *SonyF35.StillLife_LMT.Academy.BlueLightArtifactFix.exr* - `LMT.Academy.BlueLightArtifactFix.ctl` applied to *ACES/SonyF35.StillLife.exr*
-    * *SonyF35.StillLife_LMT.Academy.GamutCompress.exr* - `LMT.Academy.GamutCompress.ctl` applied to *ACES/SonyF35.StillLife.exr*
+    * *SonyF35.StillLife_LMT.Academy.ReferenceGamutCompress.exr* - `LMT.Academy.ReferenceGamutCompress.ctl` applied to *ACES/SonyF35.StillLife.exr*
     * *syntheticChart.01_LMT.Academy.ACES_0_1_1.exr* - `LMT.Academy.ACES_0_1_1.ctl` applied to *ACES/syntheticChart.01.exr*
     * *syntheticChart.01_LMT.Academy.ACES_0_2_2.exr* - `LMT.Academy.ACES_0_2_2.ctl` applied to *ACES/syntheticChart.01.exr*
     * *syntheticChart.01_LMT.Academy.ACES_0_7_1.exr* - `LMT.Academy.ACES_0_7_1.ctl` applied to *ACES/syntheticChart.01.exr*
     * *syntheticChart.01_LMT.Academy.BlueLightArtifactFix.exr* - `LMT.Academy.BlueLightArtifactFix.ctl` applied to *ACES/syntheticChart.01.exr*
-    * *syntheticChart.01_LMT.Academy.GamutCompress.exr* - `LMT.Academy.GamutCompress.ctl` applied to *ACES/syntheticChart.01.exr*
+    * *syntheticChart.01_LMT.Academy.ReferenceGamutCompress.exr* - `LMT.Academy.ReferenceGamutCompress.ctl` applied to *ACES/syntheticChart.01.exr*
   * **OCES/**
     * *SonyF35.StillLife.exr* - `RRT.ctl` applied to *ACES/SonyF35.StillLife.exr*
     * *syntheticChart.01.exr* - `RRT.ctl` applied to *ACES/syntheticChart.01.exr*

--- a/transforms/ctl/lmt/InvLMT.Academy.ReferenceGamutCompress.ctl
+++ b/transforms/ctl/lmt/InvLMT.Academy.ReferenceGamutCompress.ctl
@@ -40,7 +40,7 @@ const float PWR = 1.2;
 
 
 // Calculate compressed distance
-float compress(float dist, float lim, float thr, float pwr, bool invert)
+float uncompress(float dist, float lim, float thr, float pwr)
 {
     float comprDist;
     float scl;
@@ -58,16 +58,11 @@ float compress(float dist, float lim, float thr, float pwr, bool invert)
         nd = (dist - thr) / scl;
         p = pow(nd, pwr);
 
-        if (!invert) {
-            comprDist = thr + scl * nd / (pow(1.0 + p, 1.0 / pwr)); // Compress
+        if (dist > (thr + scl)) {
+            comprDist = dist; // Avoid singularity
         }
         else {
-            if (dist > (thr + scl)) {
-                comprDist = dist; // Avoid singularity
-            }
-            else {
-                comprDist = thr + scl * pow(-(p / (p - 1.0)), 1.0 / pwr); // Uncompress
-            }
+            comprDist = thr + scl * pow(-(p / (p - 1.0)), 1.0 / pwr); // Uncompress
         }
     }
 
@@ -85,8 +80,7 @@ void main
     output varying float rOut,
     output varying float gOut,
     output varying float bOut,
-    output varying float aOut,
-    input uniform bool invert = true
+    output varying float aOut
 ) 
 { 
     // Source values
@@ -113,9 +107,9 @@ void main
 
     // Compress distance with parameterized shaper function
     float comprDist[3] = {
-        compress(dist[0], LIM_CYAN, THR_CYAN, PWR, invert),
-        compress(dist[1], LIM_MAGENTA, THR_MAGENTA, PWR, invert),
-        compress(dist[2], LIM_YELLOW, THR_YELLOW, PWR, invert)
+        uncompress(dist[0], LIM_CYAN, THR_CYAN, PWR),
+        uncompress(dist[1], LIM_MAGENTA, THR_MAGENTA, PWR),
+        uncompress(dist[2], LIM_YELLOW, THR_YELLOW, PWR)
     };
 
     // Recalculate RGB from compressed distance and achromatic

--- a/transforms/ctl/lmt/InvLMT.Academy.ReferenceGamutCompress.ctl
+++ b/transforms/ctl/lmt/InvLMT.Academy.ReferenceGamutCompress.ctl
@@ -1,0 +1,136 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:InvLMT.Academy.ReferenceGamutCompress.a1.3.0</ACEStransformID>
+// <ACESuserName>ACES 1.3 Inverse Look - Reference Gamut Compress</ACESuserName>
+
+//
+// Inverse of reference gamut compression algorithm
+//
+
+//
+// Usage:
+//  This transform is intended to be applied to AP0 data, immediately after the IDT, so
+//  that all grading or compositing operations are downstream of the compression, and
+//  therefore work only with positive AP1 values.
+//
+// Input and output: ACES2065-1
+//
+
+
+
+import "ACESlib.Transform_Common";
+
+
+
+/* --- Gamut Compress Parameters --- */
+// Distance from achromatic which will be compressed to the gamut boundary
+// Values calculated to encompass the encoding gamuts of common digital cinema cameras
+const float LIM_CYAN =  1.147;
+const float LIM_MAGENTA = 1.264;
+const float LIM_YELLOW = 1.312;
+
+// Percentage of the core gamut to protect
+// Values calculated to protect all the colors of the ColorChecker Classic 24 as given by
+// ISO 17321-1 and Ohta (1997)
+const float THR_CYAN = 0.815;
+const float THR_MAGENTA = 0.803;
+const float THR_YELLOW = 0.880;
+
+// Aggressiveness of the compression curve
+const float PWR = 1.2;
+
+
+
+// Calculate compressed distance
+float compress(float dist, float lim, float thr, float pwr, bool invert)
+{
+    float comprDist;
+    float scl;
+    float nd;
+    float p;
+
+    if (dist < thr) {
+        comprDist = dist; // No compression below threshold
+    }
+    else {
+        // Calculate scale factor for y = 1 intersect
+        scl = (lim - thr) / pow(pow((1.0 - thr) / (lim - thr), -pwr) - 1.0, 1.0 / pwr);
+
+        // Normalize distance outside threshold by scale factor
+        nd = (dist - thr) / scl;
+        p = pow(nd, pwr);
+
+        if (!invert) {
+            comprDist = thr + scl * nd / (pow(1.0 + p, 1.0 / pwr)); // Compress
+        }
+        else {
+            if (dist > (thr + scl)) {
+                comprDist = dist; // Avoid singularity
+            }
+            else {
+                comprDist = thr + scl * pow(-(p / (p - 1.0)), 1.0 / pwr); // Uncompress
+            }
+        }
+    }
+
+    return comprDist;
+}
+
+
+
+void main 
+(
+    input varying float rIn, 
+    input varying float gIn, 
+    input varying float bIn, 
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut,
+    input uniform bool invert = true
+) 
+{ 
+    // Source values
+    float ACES[3] = {rIn, gIn, bIn};
+
+    // Convert to ACEScg
+    float linAP1[3] = mult_f3_f44(ACES, AP0_2_AP1_MAT);
+
+    // Achromatic axis
+    float ach = max_f3(linAP1);
+
+    // Distance from the achromatic axis for each color component aka inverse RGB ratios
+    float dist[3];
+    if (ach == 0.0) {
+        dist[0] = 0.0;
+        dist[1] = 0.0;
+        dist[2] = 0.0;
+    }
+    else {
+        dist[0] = (ach - linAP1[0]) / fabs(ach);
+        dist[1] = (ach - linAP1[1]) / fabs(ach);
+        dist[2] = (ach - linAP1[2]) / fabs(ach);
+    }
+
+    // Compress distance with parameterized shaper function
+    float comprDist[3] = {
+        compress(dist[0], LIM_CYAN, THR_CYAN, PWR, invert),
+        compress(dist[1], LIM_MAGENTA, THR_MAGENTA, PWR, invert),
+        compress(dist[2], LIM_YELLOW, THR_YELLOW, PWR, invert)
+    };
+
+    // Recalculate RGB from compressed distance and achromatic
+    float comprLinAP1[3] = {
+        ach - comprDist[0] * fabs(ach),
+        ach - comprDist[1] * fabs(ach),
+        ach - comprDist[2] * fabs(ach)
+    };
+
+    // Convert back to ACES2065-1
+    ACES = mult_f3_f44(comprLinAP1, AP1_2_AP0_MAT);
+
+    // Write output
+    rOut = ACES[0];
+    gOut = ACES[1];
+    bOut = ACES[2];
+    aOut = aIn;
+}

--- a/transforms/ctl/lmt/InvLMT.Academy.ReferenceGamutCompress.ctl
+++ b/transforms/ctl/lmt/InvLMT.Academy.ReferenceGamutCompress.ctl
@@ -1,4 +1,4 @@
-// <ACEStransformID>urn:ampas:aces:transformId:v1.5:InvLMT.Academy.ReferenceGamutCompress.a1.3.0</ACEStransformID>
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:InvLMT.Academy.ReferenceGamutCompress.a1.v1.0</ACEStransformID>
 // <ACESuserName>ACES 1.3 Inverse Look - Reference Gamut Compress</ACESuserName>
 
 //

--- a/transforms/ctl/lmt/LMT.Academy.ReferenceGamutCompress.ctl
+++ b/transforms/ctl/lmt/LMT.Academy.ReferenceGamutCompress.ctl
@@ -50,7 +50,7 @@ const float PWR = 1.2;
 
 
 // Calculate compressed distance
-float compress(float dist, float lim, float thr, float pwr, bool invert)
+float compress(float dist, float lim, float thr, float pwr)
 {
     float comprDist;
     float scl;
@@ -68,17 +68,7 @@ float compress(float dist, float lim, float thr, float pwr, bool invert)
         nd = (dist - thr) / scl;
         p = pow(nd, pwr);
 
-        if (!invert) {
-            comprDist = thr + scl * nd / (pow(1.0 + p, 1.0 / pwr)); // Compress
-        }
-        else {
-            if (dist > (thr + scl)) {
-                comprDist = dist; // Avoid singularity
-            }
-            else {
-                comprDist = thr + scl * pow(-(p / (p - 1.0)), 1.0 / pwr); // Uncompress
-            }
-        }
+        comprDist = thr + scl * nd / (pow(1.0 + p, 1.0 / pwr)); // Compress
     }
 
     return comprDist;
@@ -95,8 +85,7 @@ void main
     output varying float rOut,
     output varying float gOut,
     output varying float bOut,
-    output varying float aOut,
-    input uniform bool invert = false
+    output varying float aOut
 ) 
 { 
     // Source values
@@ -123,9 +112,9 @@ void main
 
     // Compress distance with parameterized shaper function
     float comprDist[3] = {
-        compress(dist[0], LIM_CYAN, THR_CYAN, PWR, invert),
-        compress(dist[1], LIM_MAGENTA, THR_MAGENTA, PWR, invert),
-        compress(dist[2], LIM_YELLOW, THR_YELLOW, PWR, invert)
+        compress(dist[0], LIM_CYAN, THR_CYAN, PWR),
+        compress(dist[1], LIM_MAGENTA, THR_MAGENTA, PWR),
+        compress(dist[2], LIM_YELLOW, THR_YELLOW, PWR)
     };
 
     // Recalculate RGB from compressed distance and achromatic

--- a/transforms/ctl/lmt/LMT.Academy.ReferenceGamutCompress.ctl
+++ b/transforms/ctl/lmt/LMT.Academy.ReferenceGamutCompress.ctl
@@ -1,4 +1,4 @@
-// <ACEStransformID>urn:ampas:aces:transformId:v1.5:LMT.Academy.ReferenceGamutCompress.a1.3.0</ACEStransformID>
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:LMT.Academy.ReferenceGamutCompress.a1.v1.0</ACEStransformID>
 // <ACESuserName>ACES 1.3 Look - Reference Gamut Compress</ACESuserName>
 
 //

--- a/transforms/ctl/lmt/LMT.Academy.ReferenceGamutCompress.ctl
+++ b/transforms/ctl/lmt/LMT.Academy.ReferenceGamutCompress.ctl
@@ -1,5 +1,5 @@
-// <ACEStransformID>urn:ampas:aces:transformId:v1.5:LMT.Academy.GamutCompress.a1.3.0</ACEStransformID>
-// <ACESuserName>ACES 1.3 Look - Gamut Compress</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:LMT.Academy.ReferenceGamutCompress.a1.3.0</ACEStransformID>
+// <ACESuserName>ACES 1.3 Look - Reference Gamut Compress</ACESuserName>
 
 //
 // Gamut compression algorithm to bring out-of-gamut scene-referred values into AP1


### PR DESCRIPTION
This branch incorporates changes to relabel the gamut compression algorithm that was introduced in v1.2 as the Reference Gamut Compress function. It also separates the transform into distinct forward and inverse files, splitting up the code that was formerly encapsulated in a single transform file.