### PR TITLE
Add LogC4 to CSC

### DIFF
--- a/transforms/ctl/csc/arri/ACEScsc.Academy.ACES_to_LogC4.ctl
+++ b/transforms/ctl/csc/arri/ACEScsc.Academy.ACES_to_LogC4.ctl
@@ -1,0 +1,61 @@
+
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_LogC4.a1.1.0</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC4</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES to ARRI LogC4
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to ARRI LogC4
+//
+
+
+
+import "ACESlib.Utilities_Color";
+
+
+const float AP0_2_AWG4_MAT[3][3] = 
+                        calculate_rgb_to_rgb_matrix( AP0, 
+                                                     ARRI_ALEXA_WG4_PRI, 
+                                                     CONE_RESP_MAT_CAT02);
+
+
+// LogC4 Curve Encoding Function
+float RelativeSceneLinearToNormalizedLogC4( float x) {
+
+    // Constants
+    const float a = (pow(2.0, 18.0) - 16.0) / 117.45;
+    const float b = (1023.0 - 95.0) / 1023.0;
+    const float c = 95.0 / 1023.0;
+    const float s = (7.0 * log(2.0) * pow(2.0, 7.0 - 14.0 * c / b)) / (a * b);
+    const float t = (pow(2.0, 14.0 * (-c / b) + 6.0) - 64.0) / a;
+
+    if (x < t) {
+        return (x - t) / s;
+    }
+
+    return (log2(a * x + 64.0) - 6.0) / 14.0 * b + c;
+}
+
+
+
+void main
+(   
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+    float ACES[3] = { rIn, gIn, bIn};
+
+    float lin_AWG4[3] = mult_f3_f33( ACES, AP0_2_AWG4_MAT);
+
+    rOut = RelativeSceneLinearToNormalizedLogC4( lin_AWG4[0]);
+    gOut = RelativeSceneLinearToNormalizedLogC4( lin_AWG4[1]);
+    bOut = RelativeSceneLinearToNormalizedLogC4( lin_AWG4[2]);
+    aOut = aIn;
+}

--- a/transforms/ctl/csc/arri/ACEScsc.Academy.LogC4_to_ACES.ctl
+++ b/transforms/ctl/csc/arri/ACEScsc.Academy.LogC4_to_ACES.ctl
@@ -1,0 +1,65 @@
+
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.LogC4_to_ACES.a1.1.0</ACEStransformID>
+// <ACESuserName>ARRI LogC4 to ACES2065-1</ACESuserName>
+
+//
+// ACES Color Space Conversion - ARRI LogC4 to ACES
+//
+// converts ARRI LogC4 to ACES2065-1 (AP0 w/ linear encoding)
+//
+
+
+
+import "ACESlib.Utilities_Color";
+
+
+const float AWG4_2_AP0_MAT[3][3] = 
+                        calculate_rgb_to_rgb_matrix( ARRI_ALEXA_WG4_PRI, 
+                                                     AP0, 
+                                                     CONE_RESP_MAT_CAT02);
+
+
+// LogC4 Curve Decoding Function
+float normalizedLogC4ToRelativeSceneLinear( float x) {
+
+    // Constants
+    const float a = (pow(2.0, 18.0) - 16.0) / 117.45;
+    const float b = (1023.0 - 95.0) / 1023.0;
+    const float c = 95.0 / 1023.0;
+    const float s = (7.0 * log(2.0) * pow(2.0, 7.0 - 14.0 * c / b)) / (a * b);
+    const float t = (pow(2.0, 14.0 * (-c / b) + 6.0) - 64.0) / a;
+
+    if (x < 0.0) {
+        return x * s + t;
+    }
+
+    float p = 14.0 * (x - c) / b + 6.0;
+    return (pow(2.0, p) - 64.0) / a;
+}
+
+
+
+void main
+(   
+    input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+    float lin_AWG4[3];
+    lin_AWG4[0] = normalizedLogC4ToRelativeSceneLinear( rIn);
+    lin_AWG4[1] = normalizedLogC4ToRelativeSceneLinear( gIn);
+    lin_AWG4[2] = normalizedLogC4ToRelativeSceneLinear( bIn);
+
+    float ACES[3] = mult_f3_f33( lin_AWG4, AWG4_2_AP0_MAT);
+  
+    rOut = ACES[0];
+    gOut = ACES[1];
+    bOut = ACES[2];
+    aOut = aIn;
+}

--- a/transforms/ctl/lib/ACESlib.Utilities_Color.ctl
+++ b/transforms/ctl/lib/ACESlib.Utilities_Color.ctl
@@ -70,6 +70,14 @@ const Chromaticities ARRI_ALEXA_WG_PRI =
   { 0.31270,  0.32900}
 };
 
+const Chromaticities ARRI_ALEXA_WG4_PRI =
+{
+  { 0.73470,  0.26530},
+  { 0.14240,  0.85760},
+  { 0.09910, -0.03080},
+  { 0.31270,  0.32900}
+};
+
 const Chromaticities REC2020_PRI = 
 {
   { 0.70800,  0.29200},


### PR DESCRIPTION
ARRI LogC4 has been added to the IDTs, but not to the CSCs. This PR adds it to the CSCs as well, for completeness.