### PR TITLE
Only apply white scaling if `linear_scale_factor == 1.0`

### DIFF
--- a/lib/Lib.Academy.DisplayEncoding.ctl
+++ b/lib/Lib.Academy.DisplayEncoding.ctl
@@ -462,7 +462,7 @@ float[3] display_encoding( float XYZ[3],
     float XYZ_scaled[3] = mult_f_f3( PARAMS.peakLuminance/referenceLuminance, XYZ_scaled_0to1);
     
     // White point scaling
-    if (!f2_equal_to_tolerance(limitingPri.white, encodingPri.white, 1e-5)) {
+    if (!f2_equal_to_tolerance(limitingPri.white, encodingPri.white, 1e-5) && linear_scale == 1.0) {
         XYZ_scaled = scale_white( XYZ_scaled, PARAMS, false);
     }
 
@@ -496,7 +496,7 @@ float[3] display_decoding( float cv[3],
     float XYZ[3] = mult_f3_f33( RGB_display_linear, PARAMS.OUTPUT_RGB_TO_XYZ );
 
     // White scaling
-    if (!f2_equal_to_tolerance(limitingPri.white, encodingPri.white, 1e-5)) {
+    if (!f2_equal_to_tolerance(limitingPri.white, encodingPri.white, 1e-5) && linear_scale == 1.0) {
         XYZ = scale_white( XYZ, PARAMS, true);
     }
 


### PR DESCRIPTION
The scaling to fit peak white where the limiting and encoding white points do not match is not needed for DCDM encoding, since the necessary headroom is already provided by the 48/52.37 normalisation. A linear scale factor less than 1.0 seems to be a suitable way to identify that headroom is already being provided in the encoding. Without the changes in this PR, the DCDM Output Transforms will have white fitting scaling applied based on the difference between the limiting white and equal energy white, when no scaling is actually required.